### PR TITLE
Github Actionsの定期実行の表記修正

### DIFF
--- a/.github/workflows/dataset-update.yml
+++ b/.github/workflows/dataset-update.yml
@@ -2,7 +2,7 @@ name: dataset-update
 
 on:
   schedule:
-    - cron: "0 4 * * *"
+    - cron: 0 4 * * *
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
ダブルクオートを外してみる。理由としてはexecuTorchでも同じスケジュールを設定していたけどそっちにはダブルクオートがなかったから。