### PR TITLE
GitHubActionsの更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: main

--- a/.github/workflows/dataset-update.yml
+++ b/.github/workflows/dataset-update.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
           cache: "pipenv"
@@ -33,7 +33,7 @@ jobs:
         run: pipenv run pytest -q --junit-xml pytest.xml
         continue-on-error: true
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
         if: success() || failure()
         with:
           report_paths: "pytest.xml"
@@ -41,8 +41,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.6
       - name: Setup Bun
@@ -51,13 +51,13 @@ jobs:
         run: bun update "material-icon-theme"
       - name: Update Manifest
         run: bun run scripts/index.ts
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
         with:
           python-version: "3.14"
       - name: Update Dataset
         run: python scripts/app/main.py
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: Update Dataset
           reviewers: DogFortune

--- a/.github/workflows/dataset-update.yml
+++ b/.github/workflows/dataset-update.yml
@@ -51,7 +51,7 @@ jobs:
         run: bun update "material-icon-theme"
       - name: Update Manifest
         run: bun run scripts/index.ts
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
       - name: Update Dataset
@@ -59,9 +59,8 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          commit-message: Update Dataset
+          commit-message: Update material-icon-theme
           reviewers: DogFortune
           delete-branch: true
-          branch: update/theme
-          branch-suffix: timestamp
-          title: Update Dataset
+          branch: update/material-icon-theme
+          title: Update material-icon-theme


### PR DESCRIPTION
fixes #25 

# 概要
以下の通り構成を変更
- アクションのバージョン指定をタグからハッシュによる完全固定に変更
- アクションのバージョンが固定されてしまうのでDependabotによる更新監視設定を追加